### PR TITLE
Add initial sync service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # file-sync-service
-This is a file synchronization service that monitors a folder on your local machine and syncs it with a cloud storage provider (e.g., Yandex Disk). The service periodically checks for changes in the local folder (new files, updates, deletions) and mirrors those changes in the cloud storage.
+
+A simple service that monitors a local directory and mirrors any file changes to Yandex Disk. The tool uses the Yandex Disk REST API and the `watchdog` library to watch the filesystem in real time.
+
+## Requirements
+
+- Python 3.8+
+- [`requests`](https://pypi.org/project/requests/)
+- [`watchdog`](https://pypi.org/project/watchdog/)
+
+Install the dependencies with:
+
+```bash
+pip install requests watchdog
+```
+
+## Usage
+
+Provide the directory you want to watch and a valid OAuth token for Yandex Disk:
+
+```bash
+python sync_service.py <directory> <token>
+```
+
+The service will start watching the directory and upload, update or delete files on Yandex Disk as changes occur.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/sync_service.py
+++ b/sync_service.py
@@ -1,0 +1,77 @@
+import argparse
+import logging
+import os
+import time
+from pathlib import Path
+
+try:
+    from watchdog.observers import Observer
+    from watchdog.events import FileSystemEventHandler
+except ImportError as exc:  # pragma: no cover - watchdog optional
+    raise SystemExit("watchdog package is required to run the sync service") from exc
+
+from yandex_disk_client import YandexDiskClient
+
+
+logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+
+class SyncEventHandler(FileSystemEventHandler):
+    def __init__(self, client: YandexDiskClient, root: Path):
+        super().__init__()
+        self.client = client
+        self.root = root
+
+    def _remote_path(self, src_path: str) -> str:
+        rel = Path(src_path).relative_to(self.root)
+        return f"/{rel.as_posix()}"
+
+    def on_created(self, event):
+        if event.is_directory:
+            return
+        logger.info("created %s", event.src_path)
+        self.client.upload_file(event.src_path, self._remote_path(event.src_path))
+
+    def on_modified(self, event):
+        if event.is_directory:
+            return
+        logger.info("modified %s", event.src_path)
+        self.client.upload_file(event.src_path, self._remote_path(event.src_path))
+
+    def on_deleted(self, event):
+        if event.is_directory:
+            return
+        logger.info("deleted %s", event.src_path)
+        self.client.delete_file(self._remote_path(event.src_path))
+
+    def on_moved(self, event):
+        if event.is_directory:
+            return
+        logger.info("moved %s -> %s", event.src_path, event.dest_path)
+        self.client.delete_file(self._remote_path(event.src_path))
+        self.client.upload_file(event.dest_path, self._remote_path(event.dest_path))
+
+
+def run_sync(directory: str, token: str):
+    path = Path(directory).resolve()
+    client = YandexDiskClient(token)
+    event_handler = SyncEventHandler(client, path)
+    observer = Observer()
+    observer.schedule(event_handler, str(path), recursive=True)
+    observer.start()
+    logger.info("Watching %s", path)
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Watch directory and sync to Yandex Disk")
+    parser.add_argument("directory", help="Directory to watch")
+    parser.add_argument("token", help="OAuth token for Yandex Disk")
+    args = parser.parse_args()
+    run_sync(args.directory, args.token)

--- a/yandex_disk_client.py
+++ b/yandex_disk_client.py
@@ -1,0 +1,31 @@
+import os
+import requests
+
+
+class YandexDiskClient:
+    """Simple Yandex Disk REST API client."""
+
+    def __init__(self, token: str):
+        self.token = token
+        self.base_url = "https://cloud-api.yandex.net/v1/disk"
+        self.headers = {"Authorization": f"OAuth {self.token}"}
+
+    def _get_upload_url(self, path: str) -> str:
+        url = f"{self.base_url}/resources/upload"
+        params = {"path": path, "overwrite": "true"}
+        resp = requests.get(url, headers=self.headers, params=params)
+        resp.raise_for_status()
+        return resp.json().get("href")
+
+    def upload_file(self, local_path: str, remote_path: str) -> None:
+        """Upload a local file to Yandex Disk"""
+        href = self._get_upload_url(remote_path)
+        with open(local_path, "rb") as f:
+            resp = requests.put(href, files={"file": f})
+        resp.raise_for_status()
+
+    def delete_file(self, remote_path: str) -> None:
+        url = f"{self.base_url}/resources"
+        resp = requests.delete(url, headers=self.headers, params={"path": remote_path})
+        if resp.status_code not in (200, 202, 204, 404):
+            resp.raise_for_status()


### PR DESCRIPTION
## Summary
- implement `YandexDiskClient` for REST interactions
- implement `sync_service.py` using watchdog to monitor local directory
- document requirements and usage in README

## Testing
- `python -m py_compile yandex_disk_client.py sync_service.py`


------
https://chatgpt.com/codex/tasks/task_e_6859bea754c8832596e956f8b9b5d7e4